### PR TITLE
Added example configuration from Absolum project.

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,6 +1,6 @@
 ## Overview
 
-The whole ergogen config is a single YAML file.
+The whole Ergogen config is a single YAML file.
 If you prefer JSON over YAML, feel free to use it, conversion is trivial and the generator will detect the input format.
 The important thing is that the data should contain the following keys:
 
@@ -17,7 +17,7 @@ The `cases` section details how the case outlines are to be 3D-ized to form a 3D
 Finally, the `pcbs` section is used to configure KiCAD PCB templates.
 
 In the following, we'll have an in-depth discussion about each of these.
-Of course, if the declarative nature of the config causes unnecessary repetition (despite the built-in YAML references, and the ergogen-based inheritance detailed below), there's nothing stopping you from writing code that generates the config.
+Of course, if the declarative nature of the config causes unnecessary repetition (despite the built-in YAML references, and the Ergogen-based inheritance detailed below), there's nothing stopping you from writing code that generates the config.
 It brings the game to yet another abstraction level higher, so that you can use branching, loops, and parametric functions to compose a "drier" keyboard definition.
 
 
@@ -570,10 +570,11 @@ Currently, the following footprint types are supported:
 ## Phew, that's it.
 
 *Theoretically*, you should know everything to start making your own dream keyboard.
-*Realistically*, tho, this might have been a bit dense, to say the least.
-But hey, this is the full reference, what did you expect?
+*Realistically* though, this might have been a bit dense, to say the least.  But hey, this is the full reference, what did you expect?
+
+If you want to look at an example that leverages the full power of Ergogen, you can find [the Absolem project](https://github.com/mrzealot/absolem/) and its [configuration file here.](https://github.com/mrzealot/absolem/blob/master/absolem.yaml)  
 
 If you'd like to get your feet wet with easier examples, and get gradually more hard-core, let me suggest the other tutorials in the docs folder (as they become available).
-Alternatively, if you'd like to talk to a certified ergogen representative, come join us [on Discord](https://discord.gg/nbKcAZB)!
+Alternatively, if you'd like to talk to a certified Ergogen representative, come join us [on Discord](https://discord.gg/nbKcAZB)!
 It's also a great place to get in touch if you are already somewhat familiar with this whole shebang, and would like to contribute examples, tests, features, whatever.
 See you there!


### PR DESCRIPTION
This is just pulled out of the Absolum repository.  Instead of
having the raw configuration here, we could link in the docs or
README.md.  Figured that including it raw would ensure that if the
Absoulum project ever moves away from the generator that could
cause a problem.

Addresses #3 