### PR TITLE
Output SVG alongside DXF in debug mode

### DIFF
--- a/src/io.js
+++ b/src/io.js
@@ -15,6 +15,7 @@ exports.dump_model = (model, file='model', debug=false) => {
     fs.mkdirpSync(path.dirname(`${file}.dxf`))
     fs.writeFileSync(`${file}.dxf`, m.exporter.toDXF(assembly))
     if (debug) {
+        fs.writeFileSync(`${file}.svg`, m.exporter.toSVG(assembly))
         fs.writeJSONSync(`${file}.json`, assembly, {spaces: 4})
     }
 }


### PR DESCRIPTION
For each DXF file that `src/cli.js` outputs, `src/cli.js --debug` additionally outputs a corresponding JSON file. With this change, the `--debug` form also outputs an SVG file.

This is useful for getting real-time feedback while authoring a config. [I said in Discord](https://discordapp.com/channels/714176584269168732/759825860617437204/772652810176167986):

> I found a decent workflow for editing with live visual feedback:
>  1. Tweak `io.js` to output SVG alongside DXF (https://github.com/brow/ergogen/commit/3e064605fe6b73acbda0900f5547b7c40ae2787b)
>  2.  `fswatch -0 jklp.yaml | xargs -0 -n1 node src/cli.js -c jklp.yaml -o jklp --debug`
>  3. Use an SVG viewer that automatically refreshes when the file changes—e.g., Gapplin on macOS

![image](https://user-images.githubusercontent.com/238331/97936471-338eac00-1d41-11eb-8c15-67e10e368c9f.png)
