### PR TITLE
docs(readme): fix typo in web ui url link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ Supposing you have a config ready, you can use ergogen either on the command lin
 Command line usage requires `node v14.4.0+` with `npm v6.14.5+` to be installed, the repo to be checked out, `npm install` to be issued, and then simply calling the CLI interface through `node src/cli.js`.
 The `--help` switch lists the available command line options.
 
-The [web UI](https://zeaolt.hu/ergogen) is a more accessible version of the same codebase, where everything happens in your browser.
+The [web UI](https://zealot.hu/ergogen/) is a more accessible version of the same codebase, where everything happens in your browser.
 It's been patched together on a fresh Chrome-derivative, and I didn't take any care to make it compatible with older stuff, so please use something modern!
 
 As for how to prepare a valid config, please read the [reference](https://github.com/mrzealot/ergogen/blob/master/docs/reference.md), or browse the [`docs`](https://github.com/mrzealot/ergogen/tree/master/docs) folder for additional examples.


### PR DESCRIPTION
The URL typo fixed in #7 was still lingering in the second Web UI link, just making sure people don't think it's down when they click the second link :)