### PR TITLE
Fix ReferenceError: *_unit is not defined

### DIFF
--- a/src/points.js
+++ b/src/points.js
@@ -314,8 +314,8 @@ exports.parse = (config, units) => {
 
 exports.visualize = (points, units) => {
     const models = {}
-    x_unit = units.visual_x || (units.u - 1)
-    y_unit = units.visual_y || (units.u - 1)
+    const x_unit = units.visual_x || (units.u - 1)
+    const y_unit = units.visual_y || (units.u - 1)
     for (const [pname, p] of Object.entries(points)) {
         const w = p.meta.width * x_unit
         const h = p.meta.height * y_unit


### PR DESCRIPTION
While trying to set up the WebUI from a fresh rollup build I ran into the following error when generating the keyboard
`ReferenceError: x_unit is not defined`

It looks like this was recently introduced in ad5ac9c63ecce638ee322a34ef98cd916e3c2fa3 

I've simply added `const` to define these

