### PR TITLE
change `affects` to `affect` in documentation

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -167,7 +167,7 @@ points:
                 orient: num # default = 0
                 shift: [x, y] # default = [0, 0]
                 rotate: num # default = 0
-                affects: string containing any of x, y, or r # default = xyr
+                affect: string containing any of x, y, or r # default = xyr
             columns:
                 column_name: <column def>
                 ...
@@ -191,7 +191,7 @@ This initial position can then be changed with the `orient`, `shift`, and `rotat
 `shift` adds extra translation, while the difference between `orient` and `rotate` is whether they add their rotation before or after the translation.
 
 Also note that anywhere an anchor can be specified, a list of anchors is also valid.
-It would be meaningless, though, if each subsequent anchor would override the previous one, so the `affects` clause helps to affect only certain dimensions of the anchor.
+It would be meaningless, though, if each subsequent anchor would override the previous one, so the `affect` clause helps to affect only certain dimensions of the anchor.
 It can be declared using a string containing any of `x`, `y`, or `r`, which stand for the x and y coordinates and the rotation of the anchor, respectively.
 
 Once we know _where_ to start, we can describe the `columns` of our layout.

--- a/meta/schema.json
+++ b/meta/schema.json
@@ -33,7 +33,7 @@
                                         "description": "Add rotation after translation",
                                         "type": "number"
                                     },
-                                    "affects": {
+                                    "affect": {
                                         "description": "Affect only certain dimensions of the anchor",
                                         "type": "string"
                                     }

--- a/roadmap.md
+++ b/roadmap.md
@@ -10,7 +10,7 @@
 
 - Global column-level attributes like spread
 - More generic anchors or distances?
-    - Intersect support for anchor affects clauses, which (combined with the math formulas and possible trigonometric functions) should allow for every use case we've discussed so far
+    - Intersect support for anchor affect clauses, which (combined with the math formulas and possible trigonometric functions) should allow for every use case we've discussed so far
 - Add a way to propagate creator/board/version info from the pcb section to the kicad template
 - Add a way to globally enable/disable references (`ref_hide`)
 - SVG input (for individual outlines, or even combinations parsed by line color, etc.)


### PR DESCRIPTION
Somehow, the documentation uses `affects`, while implementation and tests use `affect`.  For consistency with the other keys, I suggest to change the documentation.