### PR TITLE
Fixed rotary encoder footprint

### DIFF
--- a/src/footprints/rotary.js
+++ b/src/footprints/rotary.js
@@ -58,15 +58,15 @@ module.exports = {
             (fp_circle (center -0.12 -0.04) (end 2.88 -0.04) (layer F.Fab) (width 0.12))
 
             ${''/* pin names */}
-            (pad A thru_hole rect (at -7.62 -2.54) (size 2 2) (drill 1) (layers *.Cu *.Mask) ${p.net.A.str}))
-            (pad C thru_hole circle (at -7.62 -0.04) (size 2 2) (drill 1) (layers *.Cu *.Mask) ${p.net.C.str}))
-            (pad B thru_hole circle (at -7.62 2.46) (size 2 2) (drill 1) (layers *.Cu *.Mask) ${p.net.B.str}))
-            (pad 1 thru_hole circle (at 6.88 -2.54) (size 1.5 1.5) (drill 1) (layers *.Cu *.Mask) ${p.net.from.str}))
+            (pad A thru_hole rect (at -7.62 -2.54 ${p.rot}) (size 2 2) (drill 1) (layers *.Cu *.Mask) ${p.net.A.str})
+            (pad C thru_hole circle (at -7.62 -0.04) (size 2 2) (drill 1) (layers *.Cu *.Mask) ${p.net.C.str})
+            (pad B thru_hole circle (at -7.62 2.46) (size 2 2) (drill 1) (layers *.Cu *.Mask) ${p.net.B.str})
+            (pad 1 thru_hole circle (at 6.88 -2.54) (size 1.5 1.5) (drill 1) (layers *.Cu *.Mask) ${p.net.from.str})
             (pad 2 thru_hole circle (at 6.88 2.46) (size 1.5 1.5) (drill 1) (layers *.Cu *.Mask) ${p.net.to.str})
 
             ${''/* Legs */}
-            (pad "" thru_hole rect (at -0.12 -5.64) (size 3.2 2) (drill oval 2.8 1.5) (layers *.Cu *.Mask)))
-            (pad "" thru_hole rect (at -0.12 5.56) (size 3.2 2) (drill oval 2.8 1.5) (layers *.Cu *.Mask)))
+            (pad "" thru_hole rect (at -0.12 -5.64 ${p.rot}) (size 3.2 2) (drill oval 2.8 1.5) (layers *.Cu *.Mask))
+            (pad "" thru_hole rect (at -0.12 5.56 ${p.rot})  (size 3.2 2) (drill oval 2.8 1.5) (layers *.Cu *.Mask))
         )
     `
 }


### PR DESCRIPTION
Previously the encoder footprint would not work, causing Kicad to error out when trying to open a generated PCB.  Once fixed, the footprint added had the square pads / through holes not rotated with the rest of the footprint.

This pull request fixes a number of unbalanced parentheses which caused Kicad to error out and adds rotation to the square holes in footprint.

After fixing Kicad errors:
![unaligned](https://user-images.githubusercontent.com/1487206/140647701-b0b16901-6405-4408-892c-ba8a5a13b920.png)

After fixing rotation issues:
![aligned](https://user-images.githubusercontent.com/1487206/140647726-dcec4ccb-f548-46ef-a8e4-c00ae41ba052.png)

